### PR TITLE
*ui.rc files should now be installed in the ${KXMLGUI_INSTALL_DIR} direc...

### DIFF
--- a/krusader/CMakeLists.txt
+++ b/krusader/CMakeLists.txt
@@ -122,10 +122,7 @@ install(TARGETS krusader ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(PROGRAMS krusader.desktop
               krusader_root-mode.desktop
         DESTINATION ${XDG_APPS_INSTALL_DIR} )
-install(FILES krusaderui.rc
-              krusaderlisterui.rc
-              krviewer.rc
-              midnight_commander.color
+install(FILES midnight_commander.color
               total_commander.color
               total_commander.keymap
               total_commander.keymap.info
@@ -133,6 +130,11 @@ install(FILES krusaderui.rc
               layout.xml
               splash.png
         DESTINATION ${DATA_INSTALL_DIR}/krusader)
+        
+install(FILES krusaderui.rc
+              krusaderlisterui.rc
+              krviewer.rc
+        DESTINATION ${KXMLGUI_INSTALL_DIR}/krusader)
 
 # TODO KF5 port (change to ecm_install_icons)
 #kde4_install_icons( ${ICON_INSTALL_DIR} )


### PR DESCRIPTION
I know it's a small thing but https://community.kde.org/Frameworks/Porting_Notes says .rc files shoud be in another location now (I also had to update the XDG_DATA_DIRS variable because I installed krusader into a non-standard location before the files were found; KDEDIRS isn't used anymore).
